### PR TITLE
Fix Jekyll server script

### DIFF
--- a/run_server.sh
+++ b/run_server.sh
@@ -1,1 +1,2 @@
-bundle exec jekyll liveserve
+#!/bin/bash
+bundle exec jekyll serve --livereload


### PR DESCRIPTION
## Summary
- use correct command in `run_server.sh`

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bash run_server.sh` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6892d9fb86f8832a90828a9752da3d9a