### PR TITLE
Add responsive photography gallery to about page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -139,17 +139,241 @@ Beyond academics, I'm an enthusiast in photography and filming. <br>
 ## Photography
 ### Hong Kong, China. (2024.12)
 
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Neon nights and harborside horizons.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk1.jpg" alt="Hong Kong scene 1">
+      <figcaption>Hong Kong · Frame 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk2.jpg" alt="Hong Kong scene 2">
+      <figcaption>Hong Kong · Frame 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk3.jpg" alt="Hong Kong scene 3">
+      <figcaption>Hong Kong · Frame 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk4.jpg" alt="Hong Kong scene 4">
+      <figcaption>Hong Kong · Frame 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk5.jpg" alt="Hong Kong scene 5">
+      <figcaption>Hong Kong · Frame 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk6.jpg" alt="Hong Kong scene 6">
+      <figcaption>Hong Kong · Frame 6</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk7.jpg" alt="Hong Kong scene 7">
+      <figcaption>Hong Kong · Frame 7</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk8.jpg" alt="Hong Kong scene 8">
+      <figcaption>Hong Kong · Frame 8</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk9.jpg" alt="Hong Kong scene 9">
+      <figcaption>Hong Kong · Frame 9</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk10.jpg" alt="Hong Kong scene 10">
+      <figcaption>Hong Kong · Frame 10</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk11.jpg" alt="Hong Kong scene 11">
+      <figcaption>Hong Kong · Frame 11</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk12.jpg" alt="Hong Kong scene 12">
+      <figcaption>Hong Kong · Frame 12</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk13.jpg" alt="Hong Kong scene 13">
+      <figcaption>Hong Kong · Frame 13</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk14.jpg" alt="Hong Kong scene 14">
+      <figcaption>Hong Kong · Frame 14</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk15.jpg" alt="Hong Kong scene 15">
+      <figcaption>Hong Kong · Frame 15</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk16.jpg" alt="Hong Kong scene 16">
+      <figcaption>Hong Kong · Frame 16</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk17.jpg" alt="Hong Kong scene 17">
+      <figcaption>Hong Kong · Frame 17</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk18.jpg" alt="Hong Kong scene 18">
+      <figcaption>Hong Kong · Frame 18</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk19.jpg" alt="Hong Kong scene 19">
+      <figcaption>Hong Kong · Frame 19</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk20.jpg" alt="Hong Kong scene 20">
+      <figcaption>Hong Kong · Frame 20</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk21.jpg" alt="Hong Kong scene 21">
+      <figcaption>Hong Kong · Frame 21</figcaption>
+    </figure>
+  </div>
+</div>
+
 ### Nanjing, Jiangsu, China. (2023.10)
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Autumn tones along the ancient walls.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/nanjing/nanjing_1.jpg" alt="Nanjing city scene 1">
+      <figcaption>Nanjing · Moment 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/nanjing/nanjing_2.jpg" alt="Nanjing city scene 2">
+      <figcaption>Nanjing · Moment 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/nanjing/nanjing_3.jpg" alt="Nanjing city scene 3">
+      <figcaption>Nanjing · Moment 3</figcaption>
+    </figure>
+  </div>
+</div>
 
 ### New York, United States. (2025.11)
 
-### Kunming & Dali, Yunan, China. (2025.3)
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Stay tuned—New York frames are on the way.</p>
+</div>
 
-### Qingdao & Weihai, Shandong, China. (2023.7)
+### Kunming &amp; Dali, Yunan, China. (2025.3)
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Highland light and serene lakeside mornings.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali1.jpg" alt="Kunming and Dali snapshot 1">
+      <figcaption>Kunming &amp; Dali · Story 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali2.jpg" alt="Kunming and Dali snapshot 2">
+      <figcaption>Kunming &amp; Dali · Story 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali3.jpg" alt="Kunming and Dali snapshot 3">
+      <figcaption>Kunming &amp; Dali · Story 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali4.jpg" alt="Kunming and Dali snapshot 4">
+      <figcaption>Kunming &amp; Dali · Story 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali5.jpg" alt="Kunming and Dali snapshot 5">
+      <figcaption>Kunming &amp; Dali · Story 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali6.jpg" alt="Kunming and Dali snapshot 6">
+      <figcaption>Kunming &amp; Dali · Story 6</figcaption>
+    </figure>
+  </div>
+</div>
+
+### Qingdao &amp; Weihai, Shandong, China. (2023.7)
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Sea breezes and coastal skylines.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_1.jpg" alt="Qingdao and Weihai coastal view 1">
+      <figcaption>Qingdao &amp; Weihai · Wave 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_2.jpg" alt="Qingdao and Weihai coastal view 2">
+      <figcaption>Qingdao &amp; Weihai · Wave 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_3.jpg" alt="Qingdao and Weihai coastal view 3">
+      <figcaption>Qingdao &amp; Weihai · Wave 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_4.jpg" alt="Qingdao and Weihai coastal view 4">
+      <figcaption>Qingdao &amp; Weihai · Wave 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_5.jpg" alt="Qingdao and Weihai coastal view 5">
+      <figcaption>Qingdao &amp; Weihai · Wave 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_6.jpg" alt="Qingdao and Weihai coastal view 6">
+      <figcaption>Qingdao &amp; Weihai · Wave 6</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_7.jpg" alt="Qingdao and Weihai coastal view 7">
+      <figcaption>Qingdao &amp; Weihai · Wave 7</figcaption>
+    </figure>
+  </div>
+</div>
 
 ### Suzhou, Jiangsu, China. (2021.3-2022.11)
 
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Water towns and quiet alleyways.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2021.3_1.jpg" alt="Suzhou water town memory 1">
+      <figcaption>Suzhou · Memory 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_1.jpg" alt="Suzhou water town memory 2">
+      <figcaption>Suzhou · Memory 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_2.jpg" alt="Suzhou water town memory 3">
+      <figcaption>Suzhou · Memory 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_3.jpg" alt="Suzhou water town memory 4">
+      <figcaption>Suzhou · Memory 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_4.jpg" alt="Suzhou water town memory 5">
+      <figcaption>Suzhou · Memory 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.10_1.jpg" alt="Suzhou water town memory 6">
+      <figcaption>Suzhou · Memory 6</figcaption>
+    </figure>
+  </div>
+</div>
+
 ### Zhoushan, Zhejiang, China. (2024.4)
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Island tides meeting morning mist.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_1.jpg" alt="Zhoushan island breeze 1">
+      <figcaption>Zhoushan · Tide 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_2.jpg" alt="Zhoushan island breeze 2">
+      <figcaption>Zhoushan · Tide 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_3.jpg" alt="Zhoushan island breeze 3">
+      <figcaption>Zhoushan · Tide 3</figcaption>
+    </figure>
+  </div>
+</div>
 
 
 

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -202,6 +202,69 @@
   }
 }
 
+/* photography gallery */
+.photo-gallery {
+  margin: 1.5rem 0 2.5rem;
+}
+
+.photo-gallery__title {
+  font-size: 0.95rem;
+  margin: 0.35rem 0 0;
+  color: rgba(31, 45, 61, 0.72);
+}
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.photo-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #f8f9fb;
+  box-shadow: 0 8px 24px rgba(31, 45, 61, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.photo-card img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.35s ease;
+}
+
+.photo-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(31, 45, 61, 0.12);
+}
+
+.photo-card:hover img {
+  transform: scale(1.05);
+}
+
+.photo-card figcaption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem 0.75rem;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.55) 100%);
+  color: #fff;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.photo-card:hover figcaption,
+.photo-card:focus-within figcaption {
+  opacity: 1;
+}
+
 /*
    Social sharing
    ========================================================================== */


### PR DESCRIPTION
## Summary
- add responsive gallery styles for the photography section
- embed photography albums from the `photography` directory on the About page with captions

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69098237e18c832aa79cf827c6b73495