### PR TITLE
Move photography galleries to dedicated portfolio page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,3 +17,5 @@
 
    - title: "Gallery"
      url: "#gallery"
+   - title: "Photography Portfolio"
+     url: "/photography/"

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -137,19 +137,36 @@ Beyond academics, I'm an enthusiast in photography and filming. <br>
 - *2022.06* · <strong style="color: #4b6aa1;"><a href="https://b23.tv/qwlfICM" style="color: #4b6aa1; text-decoration: none;">Bond with Promise</a></strong> (Music Video) — Director, Director of Photography, & Editor
 
 ## Photography
-### Hong Kong, China. (2024.12)
+To keep the home page lightweight, here are a few highlights from recent shoots. Dive into the full stories on the dedicated [photography portfolio](/photography/).
 
-### Nanjing, Jiangsu, China. (2023.10)
+<div class="photo-gallery photo-gallery--preview">
+  <p class="photo-gallery__title">A rotating trio of frames from Hong Kong, Yunnan, and Zhejiang.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk3.jpg" alt="A night view of Hong Kong's skyline">
+      <figcaption>Hong Kong · Harbor Glow</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali2.jpg" alt="Sunrise over the water in Dali">
+      <figcaption>Kunming &amp; Dali · Sunrise Stillness</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_2.jpg" alt="Misty cliffs in Zhoushan">
+      <figcaption>Zhoushan · Morning Mist</figcaption>
+    </figure>
+  </div>
+</div>
 
-### New York, United States. (2025.11)
-
-### Kunming & Dali, Yunan, China. (2025.3)
-
-### Qingdao & Weihai, Shandong, China. (2023.7)
-
-### Suzhou, Jiangsu, China. (2021.3-2022.11)
-
-### Zhoushan, Zhejiang, China. (2024.4)
+<h4 class="photo-section__heading">Featured Destinations</h4>
+<ul class="photo-album-links">
+  <li><a href="/photography/#hong-kong">Hong Kong, China (2024.12)</a></li>
+  <li><a href="/photography/#nanjing">Nanjing, Jiangsu, China (2023.10)</a></li>
+  <li><a href="/photography/#new-york">New York, United States (2025.11)</a></li>
+  <li><a href="/photography/#kunming-dali">Kunming &amp; Dali, Yunnan, China (2025.3)</a></li>
+  <li><a href="/photography/#qingdao-weihai">Qingdao &amp; Weihai, Shandong, China (2023.7)</a></li>
+  <li><a href="/photography/#suzhou">Suzhou, Jiangsu, China (2021.3–2022.11)</a></li>
+  <li><a href="/photography/#zhoushan">Zhoushan, Zhejiang, China (2024.4)</a></li>
+</ul>
 
 
 

--- a/_pages/photography.md
+++ b/_pages/photography.md
@@ -1,0 +1,268 @@
+---
+layout: single
+permalink: /photography/
+title: "Photography"
+author_profile: true
+---
+
+# 📸 Photography Portfolio
+
+Welcome to a curated look at the journeys I have documented around China and beyond. Each gallery pairs a short narrative with a grid of images pulled directly from my `photography/` collection.
+
+<div class="photo-index">
+  <h2 class="photo-index__heading">Destinations</h2>
+  <ul class="photo-album-links">
+    <li><a href="#hong-kong">Hong Kong, China (2024.12)</a></li>
+    <li><a href="#nanjing">Nanjing, Jiangsu, China (2023.10)</a></li>
+    <li><a href="#new-york">New York, United States (2025.11)</a></li>
+    <li><a href="#kunming-dali">Kunming &amp; Dali, Yunnan, China (2025.3)</a></li>
+    <li><a href="#qingdao-weihai">Qingdao &amp; Weihai, Shandong, China (2023.7)</a></li>
+    <li><a href="#suzhou">Suzhou, Jiangsu, China (2021.3–2022.11)</a></li>
+    <li><a href="#zhoushan">Zhoushan, Zhejiang, China (2024.4)</a></li>
+  </ul>
+</div>
+
+## City Lights &amp; Skylines
+
+### Hong Kong, China. (2024.12) {#hong-kong}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Neon nights and harborside horizons.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk1.jpg" alt="Hong Kong scene 1">
+      <figcaption>Hong Kong · Frame 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk2.jpg" alt="Hong Kong scene 2">
+      <figcaption>Hong Kong · Frame 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk3.jpg" alt="Hong Kong scene 3">
+      <figcaption>Hong Kong · Frame 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk4.jpg" alt="Hong Kong scene 4">
+      <figcaption>Hong Kong · Frame 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk5.jpg" alt="Hong Kong scene 5">
+      <figcaption>Hong Kong · Frame 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk6.jpg" alt="Hong Kong scene 6">
+      <figcaption>Hong Kong · Frame 6</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk7.jpg" alt="Hong Kong scene 7">
+      <figcaption>Hong Kong · Frame 7</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk8.jpg" alt="Hong Kong scene 8">
+      <figcaption>Hong Kong · Frame 8</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk9.jpg" alt="Hong Kong scene 9">
+      <figcaption>Hong Kong · Frame 9</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk10.jpg" alt="Hong Kong scene 10">
+      <figcaption>Hong Kong · Frame 10</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk11.jpg" alt="Hong Kong scene 11">
+      <figcaption>Hong Kong · Frame 11</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk12.jpg" alt="Hong Kong scene 12">
+      <figcaption>Hong Kong · Frame 12</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk13.jpg" alt="Hong Kong scene 13">
+      <figcaption>Hong Kong · Frame 13</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk14.jpg" alt="Hong Kong scene 14">
+      <figcaption>Hong Kong · Frame 14</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk15.jpg" alt="Hong Kong scene 15">
+      <figcaption>Hong Kong · Frame 15</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk16.jpg" alt="Hong Kong scene 16">
+      <figcaption>Hong Kong · Frame 16</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk17.jpg" alt="Hong Kong scene 17">
+      <figcaption>Hong Kong · Frame 17</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk18.jpg" alt="Hong Kong scene 18">
+      <figcaption>Hong Kong · Frame 18</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk19.jpg" alt="Hong Kong scene 19">
+      <figcaption>Hong Kong · Frame 19</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk20.jpg" alt="Hong Kong scene 20">
+      <figcaption>Hong Kong · Frame 20</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/hongkong/hk21.jpg" alt="Hong Kong scene 21">
+      <figcaption>Hong Kong · Frame 21</figcaption>
+    </figure>
+  </div>
+</div>
+
+### Nanjing, Jiangsu, China. (2023.10) {#nanjing}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Autumn tones along the ancient walls.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/nanjing/nanjing_1.jpg" alt="Nanjing city scene 1">
+      <figcaption>Nanjing · Moment 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/nanjing/nanjing_2.jpg" alt="Nanjing city scene 2">
+      <figcaption>Nanjing · Moment 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/nanjing/nanjing_3.jpg" alt="Nanjing city scene 3">
+      <figcaption>Nanjing · Moment 3</figcaption>
+    </figure>
+  </div>
+</div>
+
+## Works in Progress
+
+### New York, United States. (2025.11) {#new-york}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Stay tuned—New York frames are on the way.</p>
+</div>
+
+## Mountains, Lakes &amp; Coastlines
+
+### Kunming &amp; Dali, Yunan, China. (2025.3) {#kunming-dali}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Highland light and serene lakeside mornings.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali1.jpg" alt="Kunming and Dali snapshot 1">
+      <figcaption>Kunming &amp; Dali · Story 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali2.jpg" alt="Kunming and Dali snapshot 2">
+      <figcaption>Kunming &amp; Dali · Story 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali3.jpg" alt="Kunming and Dali snapshot 3">
+      <figcaption>Kunming &amp; Dali · Story 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali4.jpg" alt="Kunming and Dali snapshot 4">
+      <figcaption>Kunming &amp; Dali · Story 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali5.jpg" alt="Kunming and Dali snapshot 5">
+      <figcaption>Kunming &amp; Dali · Story 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/kunming&amp;dali/dali6.jpg" alt="Kunming and Dali snapshot 6">
+      <figcaption>Kunming &amp; Dali · Story 6</figcaption>
+    </figure>
+  </div>
+</div>
+
+### Qingdao &amp; Weihai, Shandong, China. (2023.7) {#qingdao-weihai}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Sea breezes and coastal skylines.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_1.jpg" alt="Qingdao and Weihai coastal view 1">
+      <figcaption>Qingdao &amp; Weihai · Wave 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_2.jpg" alt="Qingdao and Weihai coastal view 2">
+      <figcaption>Qingdao &amp; Weihai · Wave 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_3.jpg" alt="Qingdao and Weihai coastal view 3">
+      <figcaption>Qingdao &amp; Weihai · Wave 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_4.jpg" alt="Qingdao and Weihai coastal view 4">
+      <figcaption>Qingdao &amp; Weihai · Wave 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_5.jpg" alt="Qingdao and Weihai coastal view 5">
+      <figcaption>Qingdao &amp; Weihai · Wave 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_6.jpg" alt="Qingdao and Weihai coastal view 6">
+      <figcaption>Qingdao &amp; Weihai · Wave 6</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/qingdao&amp;weihai/qingdao_7.jpg" alt="Qingdao and Weihai coastal view 7">
+      <figcaption>Qingdao &amp; Weihai · Wave 7</figcaption>
+    </figure>
+  </div>
+</div>
+
+### Suzhou, Jiangsu, China. (2021.3-2022.11) {#suzhou}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Water towns and quiet alleyways.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2021.3_1.jpg" alt="Suzhou water town memory 1">
+      <figcaption>Suzhou · Memory 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_1.jpg" alt="Suzhou water town memory 2">
+      <figcaption>Suzhou · Memory 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_2.jpg" alt="Suzhou water town memory 3">
+      <figcaption>Suzhou · Memory 3</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_3.jpg" alt="Suzhou water town memory 4">
+      <figcaption>Suzhou · Memory 4</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.9_4.jpg" alt="Suzhou water town memory 5">
+      <figcaption>Suzhou · Memory 5</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/suzhou/2022.10_1.jpg" alt="Suzhou water town memory 6">
+      <figcaption>Suzhou · Memory 6</figcaption>
+    </figure>
+  </div>
+</div>
+
+### Zhoushan, Zhejiang, China. (2024.4) {#zhoushan}
+
+<div class="photo-gallery">
+  <p class="photo-gallery__title">Island tides meeting morning mist.</p>
+  <div class="photo-grid">
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_1.jpg" alt="Zhoushan island breeze 1">
+      <figcaption>Zhoushan · Tide 1</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_2.jpg" alt="Zhoushan island breeze 2">
+      <figcaption>Zhoushan · Tide 2</figcaption>
+    </figure>
+    <figure class="photo-card">
+      <img src="/photography/zhoushan/zhoushan_3.jpg" alt="Zhoushan island breeze 3">
+      <figcaption>Zhoushan · Tide 3</figcaption>
+    </figure>
+  </div>
+</div>
+

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -202,6 +202,125 @@
   }
 }
 
+/* photography gallery */
+.photo-gallery {
+  margin: 1.5rem 0 2.5rem;
+}
+
+.photo-gallery__title {
+  font-size: 0.95rem;
+  margin: 0.35rem 0 0;
+  color: rgba(31, 45, 61, 0.72);
+}
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.photo-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #f8f9fb;
+  box-shadow: 0 8px 24px rgba(31, 45, 61, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.photo-card img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.35s ease;
+}
+
+.photo-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px rgba(31, 45, 61, 0.12);
+}
+
+.photo-card:hover img {
+  transform: scale(1.05);
+}
+
+.photo-card figcaption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 0.5rem 0.75rem;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.55) 100%);
+  color: #fff;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.photo-card:hover figcaption,
+.photo-card:focus-within figcaption {
+  opacity: 1;
+}
+
+.photo-gallery--preview .photo-grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.photo-gallery--preview .photo-card {
+  box-shadow: 0 6px 18px rgba(31, 45, 61, 0.08);
+}
+
+.photo-section__heading {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2d3d;
+}
+
+.photo-album-links {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin: 0 0 2rem;
+  padding: 0;
+  list-style: none;
+}
+
+.photo-album-links li a {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: rgba(75, 106, 161, 0.1);
+  color: #1f2d3d;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.photo-album-links li a:hover,
+.photo-album-links li a:focus {
+  background: rgba(75, 106, 161, 0.18);
+  transform: translateY(-2px);
+}
+
+.photo-index {
+  margin: 2rem 0 2.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 14px;
+  background: rgba(31, 45, 61, 0.05);
+}
+
+.photo-index__heading {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1f2d3d;
+}
+
 /*
    Social sharing
    ========================================================================== */


### PR DESCRIPTION
## Summary
- create a dedicated photography portfolio page that consolidates the location-based galleries
- trim the about page to a highlight reel with quick links out to the full portfolio
- style album link grids and expose the new portfolio in site navigation

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69098237e18c832aa79cf827c6b73495